### PR TITLE
Add isMounted() to externs

### DIFF
--- a/src/react/externs/react.js
+++ b/src/react/externs/react.js
@@ -81,6 +81,12 @@ React.ReactComponent.prototype.refs;
 React.ReactComponent.prototype.propTypes;
 
 /**
+ * @return {boolean} True if mounted, false otherwise.
+ * @protected
+ */
+React.ReactComponent.prototype.isMounted() = function() {};
+
+/**
  * @param {Object} nextProps
  * @param {Function=} callback
  */


### PR DESCRIPTION
Had a scenario where I needed to use [`isMounted()`](http://facebook.github.io/react/docs/component-api.html#ismounted), but wasn't specified in this extern file.
